### PR TITLE
Correct alpha_c in docs

### DIFF
--- a/docs/technical_information.rst
+++ b/docs/technical_information.rst
@@ -316,7 +316,7 @@ When :code:`--method pi_g`, this estimation yields the fraction of labeled RNA p
 
 .. math::
 
-	\alpha_c = \frac{\pi_c}{L_c+U_c}
+	\alpha_c = \frac{L_c}{\pi_c(L_c+U_c)}
 
 where :math:`L_c` and :math:`U_c` are the numbers of labeled and unlableed RNA for cell :math:`c`. Then, using this detection rate, the corrected labeled RNA is calculated as
 


### PR DESCRIPTION
- corrected the expression of `alpha_c`, the detection rate per cell, in the technical_information.rst from docs